### PR TITLE
Allow ' in post description

### DIFF
--- a/malaria/models.py
+++ b/malaria/models.py
@@ -15,7 +15,7 @@ class Post(models.Model):
     description_post = models.CharField(max_length=5000,
                                         validators=[
                                             RegexValidator(
-                                                r'^[(A-Z)|(a-z)|(0-9)|(\s)|(\.)|(,)|(\-)|(!)|(:)]+$'
+                                                r'^[(A-Z)|(a-z)|(0-9)|(\s)|(\.)|(,)|(\-)|(!)|(:)|(\')]+$'
                                             )]
                                         )
     # link to important documents


### PR DESCRIPTION
closes #28 
Apostrophe was added to the regex validator in post description to make it work
