### PR TITLE
Enable scrolling for header

### DIFF
--- a/ui/header.html
+++ b/ui/header.html
@@ -7,7 +7,7 @@ email : ranihaileydesai@gmail.com
 <style>
     {% include "bootstrap/css/bootstrap.min.css" %}
 </style>
-<div class="navbar navbar-fixed-top" role="navigation" style="background-color:#e2d7bb; height:100px;">
+<div class="navbar navbar-fixed-top" role="navigation" style="background-color:#e2d7bb; height:100px; overflow-x:auto;">
       <div class="container">
         <div class="navbar-header">
             <div class="row">


### PR DESCRIPTION
closes: #21 and #22
By allowing the user to scroll on the header, the profile button will always be accessible.
Before:
![screen 12-22-2015 18-30-39](https://cloud.githubusercontent.com/assets/16299227/11968727/60a79356-a8dd-11e5-8093-1c069b9ebffe.gif)
After:
![screen 12-22-2015 18-33-09](https://cloud.githubusercontent.com/assets/16299227/11968731/6667abdc-a8dd-11e5-823b-88fadb6e671a.gif)
