### PR TITLE
Add radio buttons for gender select in profile edit

### DIFF
--- a/ui/edit_profile.html
+++ b/ui/edit_profile.html
@@ -48,7 +48,10 @@ email : ranihaileydesai@gmail.com
                 </tr>
                 <tr>
                     <td><label> <h4><b><font color="white">Gender:</font></b> </label></td></h4>
-                    <td><h4><input type="text" name="gender" value="{{pcuser.gender}}"></h4></td>
+                    <td>
+						<h4><input type="radio" name="gender" value="male" checked>Male</h4>
+						<h4><input type="radio" name="gender" value="female">Female</h4>
+					</td>
                 </tr>
                 <tr>
                     <td><label> <h4><b><font color="white">Location:</font></b> </label></td></h4>


### PR DESCRIPTION
closes #12.
I chose to use radio buttons instead of a drop down as it makes it more consistent with the account creation page. Lines 50-54 are the only things that were changed in the edit_profile.html (not sure why github shows the whole file as edited)
Before:
![b4](https://cloud.githubusercontent.com/assets/16299227/11999866/7673391e-aa96-11e5-8af0-7866b35c1c50.png)
After:
![now](https://cloud.githubusercontent.com/assets/16299227/11999890/fe9a6eac-aa96-11e5-9324-a557f3e465bc.png)
