### PR TITLE
Fix cancel button in edit profile page

### DIFF
--- a/ui/edit_profile.html
+++ b/ui/edit_profile.html
@@ -70,7 +70,7 @@ email : ranihaileydesai@gmail.com
         </div><br><br>
             <center>
                 <input class="btn" type="submit" name="submit" value="Update">
-                <button class="btn"><a href="/#"><font color="black">Cancel</font></a></center></button>
+                <button class="btn" type="submit" name="cancel" value="cancel"><a href="/#"><font color="black">Cancel</font></a></center></button>
             </center>
             </form><br>
             

--- a/webhub/views.py
+++ b/webhub/views.py
@@ -282,7 +282,9 @@ def edit_profile(request):
     if not request.user.is_authenticated():
         return HttpResponse(jinja_environ.get_template('index.html').render({"pcuser":None}))
 
-    
+    if 'cancel' in request.POST.keys():
+        return HttpResponse(jinja_environ.get_template('profile.html').render({"pcuser":request.user.pcuser, "profiler":request.user.pcuser}))
+
     #To remove profile picture
     if 'reset_image' in request.REQUEST.keys():
         request.user.pcuser.image = "http://vfcstatic.r.worldssl.net/assets/car_icon-e0df962a717a5db6ebc8b37e80b05713.png"


### PR DESCRIPTION
closes #14 
The cancel in the edit profile page was submitting the form, so it should now redirect back to the profile page of the user.
Before:
![after](https://cloud.githubusercontent.com/assets/16299227/12452494/ad8c3a1a-bf5c-11e5-84a2-dd37e16d27a4.gif)
After:
![before](https://cloud.githubusercontent.com/assets/16299227/12452492/a91a6fb0-bf5c-11e5-963e-7afb3daf2758.gif)
