### PR TITLE
Fix for Issue#28

### DIFF
--- a/malaria/models.py
+++ b/malaria/models.py
@@ -15,7 +15,7 @@ class Post(models.Model):
     description_post = models.TextField(max_length=20000,
                                         validators=[
                                             RegexValidator(
-                                                r'^[(A-Z)|(a-z)|(0-9)|(\n)|(\s)|(\.)|(,)|(\-)|(_)|(!)|(:)|(%)]+$'
+                                                r'^[(A-Z)|(a-z)|(0-9)|(\n)|(\s)|(\.)|(,)|(\-)|(_)|(!)|(:)|(%)|(\')]+$'
                                             )]
                                         )
     # link to important documents
@@ -56,6 +56,7 @@ class RevPost(models.Model):
     title_change = models.BooleanField(default=False)
     # change in description
     description_change = models.BooleanField(default=False)
+
 
     def __unicode__(self):
         return self.owner_rev.user.username


### PR DESCRIPTION
**Problem**
The `description_post` field in malaria/models.py did not have ' included in it.

**Solution**
Added ' in the `description_post` regexvalidator to allow ' character in that field.
