### PR TITLE
env module added

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+export DJANGO_SETTINGS_MODULE="infohub.settings"

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ Pillow==2.5.1
 psycopg2==2.5.3
 PyYAML==3.11
 static3==0.5.1
+autoenv


### PR DESCRIPTION
fixes #105 

when you cd into the current project directory. e.g.  `cd macc/`

A prompt will come up in screen 
`autoenv: Are you sure you want to allow this? (y/N)`
Press "y"

Now python manage.py runserver should work fine.

@medhach please confirm once 