### PR TITLE
Fixed 'Cancel' button on 'Edit Profile' (Issue #149 )

### DIFF
--- a/profiles/templates/profiles/edit_profile.html
+++ b/profiles/templates/profiles/edit_profile.html
@@ -90,7 +90,7 @@ email : ranihaileydesai@gmail.com
         </div><br><br>
             <center>
                 <input class="btn" type="submit" name="submit" value="Update">
-                <button class="btn"><a href="/#"><font color="black">Cancel</font></a></center></button>
+                <a href="/profile/?id={{pcuser.user.id}}" class="btn"><font color="black">Cancel</font></a></center>
             </center>
             </form><br>
             


### PR DESCRIPTION
Earlier the cancel button was submitting the form instead to redirecting to the 'View Profile' Page. 

 REASON- It occurred because the 'Cancel' button was a link placed inside an <button> tag which was placed inside a <form> tag. By default any button placed inside a form element is considered of type "submit" unless specified otherwise.

SOLUTION- Removed the < button > tag , and gave the <a> tag a bootstrap 'btn' class to give it a look of a button.