### PR TITLE
Restricted users from entering whitespace in posts and contacts (issue #185)

### DIFF
--- a/pcsa/__init__.py
+++ b/pcsa/__init__.py
@@ -1,0 +1,16 @@
+from django.forms.fields import CharField
+
+def new_clean(self, value):
+	"""
+	Strip leading and trailing whitespaces on all CharFields
+	"""
+	if value:
+		# we try/catch here, because other field subclass CharField
+		try:
+			value = value.strip()
+		except:
+			pass
+			
+	return super(CharField, self).clean(value)
+	
+CharField.clean = new_clean

--- a/pcsa/forms.py
+++ b/pcsa/forms.py
@@ -1,9 +1,47 @@
 from django.forms import ModelForm
+from django import forms
 
 from pcsa.models import PcsaPost
 
+class StripTextField(forms.CharField):
+	
+	def clean(self, value):
+		return value.strip()
 
-class PostForm(ModelForm):
+
+class StripWhitespaceMixin(object):
+	
+	def _clean_fields(self):
+		"""
+		value_from_datadict() gets the data from the data dict.
+		Each widget type knows how to retrieve its own data, because
+		some fields split data over several HTML fields
+		"""
+		value = field.widget.value_from_datadict(self.data, self.files, self.add_prefix(name))
+		
+		try:
+			if isinstance(field, CharField):
+				initial = self.initial.get(name, field.initial)
+				value = field.clean(value, initial)
+			else:
+				if isinstance(value, basestring):
+					value = field.clean(value.strip())
+				else:
+					value = field.clean(value)
+			self.cleaned_data[name] = value
+			if hasattr(self, 'clean_%s' % name):
+				value = getattr(self, 'clean_%s' % name)()
+				self.cleaned_data[name] = value
+				
+		except ValidationError as e:
+			self._errors[name] = self.error_class(e.messages)
+			if name is self.cleaned_data:
+				del self.cleaned_data[name]
+
+class PostForm(StripTextField, ModelForm):
+
+    strip_field = StripTextField()
+	
     class Meta:
         model = PcsaPost
         fields = ['title', 'description']

--- a/pcsa_GHN/__init__.py
+++ b/pcsa_GHN/__init__.py
@@ -1,0 +1,39 @@
+from django.forms.fields import CharField, IntegerField
+
+"""
+Helper method so that user cannot enter a white space to save data anywhere
+"""
+
+def new_clean(self, value):
+	"""
+	Strip leading and traling whitespaces on all the CharField values
+	"""
+	if value:
+		#if user enters any value
+		# we try/catch here, because other fields subclass CharField
+		try:
+			value = value.strip()
+		except:
+			pass
+			
+	return super(CharField, self).clean(value)
+	
+CharField.clean = new_clean
+
+
+def new_clean_number(self, value):
+	"""
+	This function lets the user enter any number only for the BigInteger
+	If the number starts from any whitespace by accident, it strips it away.
+	"""
+	if value:
+		#if the user enters any value
+		#we try to catch any exception here if it is present
+		try:
+			value = value.strip()
+		except:
+			pass
+		
+		return super(IntegerField, self).clean(value)
+		
+IntegerField.clean = new_clean_number


### PR DESCRIPTION
Previously users could just use enter and save data into the post title and description fields. Now that is checked beforehand only and necessary error message is also shown.
Fixes #185 @medhach Have a look please :)