### PR TITLE
Render same page on error and login UI change

### DIFF
--- a/infohub/templates/infohub/base.html
+++ b/infohub/templates/infohub/base.html
@@ -65,7 +65,7 @@
                 <a href="{% url 'webhub:details' %}"><h4 class="footer-mid-text">Important Details</h4></a>
                 <h4 class="footer-mid-text"> | </h4>
                 <a href="{% url 'webhub:helpPC' %}"><h4 class="footer-mid-text">Help</h4></a>
-                <p class="footer-small-text">&copy;2015 PeaceCorps</p>
+                <p class="footer-small-text">&copy;2017 PeaceCorps</p>
                 <a href="#">Return to Top</a>
             </div>
         </footer>

--- a/signup/templates/signup/signup.html
+++ b/signup/templates/signup/signup.html
@@ -9,15 +9,15 @@ email : ranihaileydesai@gmail.com
 
 <html>
 <head>
-	<title> Sign Up </title>
-	<!-- Latest compiled and minified CSS -->
-	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <title> Sign Up </title>
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
 
-	<!-- jQuery library -->
-	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+    <!-- jQuery library -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
 
-	<!-- Latest compiled JavaScript -->
-	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+    <!-- Latest compiled JavaScript -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
     <style>
     .form-outline{
         width:600px;
@@ -25,18 +25,25 @@ email : ranihaileydesai@gmail.com
         margin:0 auto;
         background-color:#0d8b97;
     }
+    .error{
+        color:red;
+        size:12;
+    }
     .ast{
-	color:red;
-	size:11;
-	padding:3;
+        color:red;
+        size:11;
+        padding:3;
     }
     </style>
 </head>
 <body>
     
     {% include "header.html" %}
-    <br><br><br><br><br><br>
+    <br><br><br><br><br><br><br>
+    <center class= "error"><p> {{text}}</p></center>
+    <br>
     
+        
     <center>
     <font color="white">
     <div class="form-outline" >
@@ -50,13 +57,13 @@ email : ranihaileydesai@gmail.com
         
         <div class="controls">
                 <label class="radio-inline">
-	                   <input maxlength=100 type="radio" name="gender" value="male" checked>Male
+                       <input maxlength=100 type="radio" name="gender" value="male" checked>Male
                 </label>
-	            <label class="radio-inline">
-	                   <input maxlength=100 type="radio" name="gender" value="female">Female
+                <label class="radio-inline">
+                       <input maxlength=100 type="radio" name="gender" value="female">Female
                 </label>
-		<label class="radio-inline">
-	                   <input maxlength=100 type="radio" name="gender" value="restricted">Prefer not to say
+        <label class="radio-inline">
+                       <input maxlength=100 type="radio" name="gender" value="restricted">Prefer not to say
                 </label>
        </div>
         

--- a/signup/views.py
+++ b/signup/views.py
@@ -4,7 +4,7 @@ import uuid
 import jinja2
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.models import User
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseRedirect
 from django.views.decorators.csrf import csrf_exempt
 from jinja2.ext import loopcontrols
 from rest_framework import status, viewsets
@@ -33,7 +33,7 @@ def signup_page(request):
         return HttpResponse(jinja_environ.get_template('redirect.html').render({"pcuser":None,"redirect_url":redirect_url}))
 
     else:
-        return HttpResponse(jinja_environ.get_template('signup.html').render({"pcuser":None}))
+        return HttpResponse(jinja_environ.get_template('signup.html').render({"pcuser":None, "text":' '}))
     
     
 #Called when a user clicks submit button in signup. Here a verification mail is also sent to the user.
@@ -49,10 +49,9 @@ def signup_do(request):
     username = request.REQUEST['username']
     password = request.REQUEST['password']
     confirmpassword = request.REQUEST['confirmpassword']
-        
+ 
     if password <> confirmpassword:
-      return HttpResponse(jinja_environ.get_template('notice.html').render({"pcuser":None,
-                                                                            "text":'<p>Passwords don\'t match. Please Enter again.</p>',"text1":'<p>Click here to go back to signup page.</p>',"link":'/signup_page/'}))
+        return HttpResponse(jinja_environ.get_template('signup.html').render({"pcuser":None, "text":'<p>Passwords don\'t match. Please Enter again.</p>'}))
     
     first_name = request.REQUEST['first_name']
     last_name = request.REQUEST['last_name']
@@ -88,7 +87,7 @@ def signup_do(request):
     send_verification_email(request)
     
     return HttpResponse(jinja_environ.get_template('notice.html').render({"pcuser":None,
-                                                                              "text":'<p>Verification Email sent! Please Check your email inbox.</p><p>To re-send verification email, click <a href=\'/send_verification_email/\'>here</a>.</p><p>Click <a href=\'/logout_do/\'>here</a> to go to the homepage and log-in again</p>', "link":'0'}))
+                                                                              "text":'<p>Verification email sent. check your inbox and verify the account.</p>',"text1":'<p>Go Back or click OK to go to signup page.</p>',"link":'/signup_page/'}))
     
 
     

--- a/ui/footer.html
+++ b/ui/footer.html
@@ -12,7 +12,7 @@
 					<li><a href="/helpPC/" title="Contact Us"">Help</a></li>
 				</ul>
 			<nav>
-			<p>&copy 2014 PeaceCorps</p>
+			<p>&copy 2017 PeaceCorps</p>
 			<a href="#top">Return to top</a>
 		</div>
 	</section>

--- a/ui/index.html
+++ b/ui/index.html
@@ -9,25 +9,26 @@ email : ranihaileydesai@gmail.com
 
 <html>
 <head>
-	<title> Welcome ! </title>
-	<!-- Latest compiled and minified CSS -->
-	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <title> Welcome ! </title>
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
 
-	<!-- jQuery library -->
-	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+    <!-- jQuery library -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
 
-	<!-- Latest compiled JavaScript -->
-	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-	<meta charset="utf-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- Latest compiled JavaScript -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 <style>  
  .ast{
-	color:red;
-	size:11;
-	padding:3;
+    color:red;
+    size:11;
+    padding:3;
+    padding-right:1em
     }
-</style
+</style>
 </head>
 <body>
     
@@ -41,15 +42,13 @@ email : ranihaileydesai@gmail.com
     <form action="/login_do/" method="post">
         <h2>Log in</h2>
         <br>
-        <h4>Username <span class="ast" >*</span></h4></font>
-        <input type="text" name="username" align="right" required>
-        <font color="white"><h4>Password <span class="ast" >*</span> </h4></font>
-        <input type="password" name="password" required>
+        <h4>Username:<span class="ast">*</span></font><input type="text" name="username" align="right" required></h4>
         <br>
-        <a href="/forgot_pass_page/"><b><u><font style="color:#2c0f00;">Forgot Password ?</font></u></b></a>
+        <font color="white"><h4>Password:<span class="ast" >*</span> </font><input type="password" name="password" required></h4>
+        <a href="/forgot_pass_page/"><b><font style="color:#2c0f00; padding-left:4em">Forgot Password?</font></b></a>
         <br><br>
         <input class="btn btn-default" type="submit" name="submit" value="Submit"><br><br>
-        <h4><b><font color="white">New User ?<a href="/signup_page/" style="color:#2c0f00;"><u> Click here to Sign Up !</u></a></font></b></h4>
+        <h4><b><font color="white">New User? <a href="/signup_page/" style="color:#cccc88; font-style: oblique;"><u>Click here</u></a> to Sign Up!</font></b></h4>
     </form>
         <br><br>
     </div>


### PR DESCRIPTION
I have made changes that include:

1. On entering erroneous data on Signup page, the url is directed to a different page to display the error messages. This would be more convenient if the error message is shown on the top of the same page. This would save a user's click. https://github.com/systers/macc/issues/231
2. A change in the UI of the login page. https://github.com/systers/macc/issues/235
3. Change the copyright year to 2017.

