### PR TITLE
View Profile page layout fixed (Issue #281)

### DIFF
--- a/profiles/templates/profiles/profile.css
+++ b/profiles/templates/profiles/profile.css
@@ -25,10 +25,11 @@
 	margin-bottom: 30px;
 }
 
-.content ul{
+.content ol{
 	text-align: left;
-	width: 200px;
-	margin: 0 auto 40px auto;
+	margin-left: 40px;
+	margin-bottom: 40px;
+	
 }
 .content li{
 	padding: 0 10px;
@@ -37,6 +38,8 @@
 .content span{
 	
 	font-variant: small-caps;
+	float:left;
+	width:250px;
 }
 .image h4{
 	width: 200px;
@@ -68,7 +71,7 @@
 	.content ul{
 		
 		width: 350px;
-		
+		list-style-type: none;
 		float: left;
 		padding-left: 30px;
 	}

--- a/profiles/templates/profiles/profile.html
+++ b/profiles/templates/profiles/profile.html
@@ -42,14 +42,14 @@ email : ranihaileydesai@gmail.com
             
                 <h3><b>User Profile</b></h3>
                
-                <ul>
+                <ol>
                     <li><span><font color="black">  First Name </span>: </font>{{profiler.user.first_name}}</li>
                     <li><span><font color="black">Last Name </span>: </font>{{profiler.user.last_name}}</li>
                     <li><span><font color="black">Email Address </span>: </font>{{profiler.user.email}}</li>
                     <li><span><font color="black">Mobile </span>:   </font>{{profiler.phone}} </li>
                     <li><span><font color="black">Gender </span>:  </font> {{profiler.gender}}</li>
                     <li><span><font color="black">Location </span>:   </font>{{profiler.location}} </li>
-                </ul>
+                </ol>
                 <div class="options">
                     {% if profiler.user.username == pcuser.user.username %}
                     <a href="javascript:void(0)" onclick="window.location.href='/edit_profile_page/?id={{profiler.id}}'" class="btn">Edit Profile</a>


### PR DESCRIPTION
The View Profile page looked as shown below. Fields did not utilize space on the right side of the page and instead shift text down. Also the values were not in a straight vertical line.
![screenshot from 2017-04-21 03 56 40](https://cloud.githubusercontent.com/assets/8321130/25256065/d9b67144-264b-11e7-96fb-b0fabcf6bad7.png)

Now it looks like this - 
![screenshot from 2017-04-21 04 32 10](https://cloud.githubusercontent.com/assets/8321130/25256193/8e5028f2-264c-11e7-85ac-b28ea45004bd.png)

